### PR TITLE
onStart resets

### DIFF
--- a/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
+++ b/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
@@ -229,8 +229,8 @@ public class GameManager {
         for (Player player : gameHunters) {
             player.getInventory().clear();
             player.setHealth(20);
-            gameSpeedrunner.setFoodLevel(20);
-            gameSpeedrunner.setSaturation(20);
+            player.setFoodLevel(20);
+            player.setSaturation(20);
             player.getInventory().addItem(trackingCompass());
         }
         if (trackingMode.equals("AUTO")) {

--- a/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
+++ b/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
@@ -218,14 +218,24 @@ public class GameManager {
     public void startGame() {
         startTime = System.nanoTime();
         isGameRunning = true;
+
+        getOverworld().setTime(0L);
+
+        gameSpeedrunner.getInventory().clear();
+        gameSpeedrunner.setHealth(20);
+        gameSpeedrunner.setFoodLevel(20);
+        gameSpeedrunner.setSaturation(20);
+
         for (Player player : gameHunters) {
+            player.getInventory().clear();
+            player.setHealth(20);
+            gameSpeedrunner.setFoodLevel(20);
+            gameSpeedrunner.setSaturation(20);
             player.getInventory().addItem(trackingCompass());
         }
         if (trackingMode.equals("AUTO")) {
             autoTrackingTask = new AutoTrackingTask(this);
             autoTrackingTask.runTaskTimer(compassTracker, 0, 20L * trackingInterval);
-        } else {
-            speedrunnerLocations.put(gameSpeedrunner.getWorld(), gameSpeedrunner.getLocation());
         }
         Bukkit.broadcastMessage(ChatColor.GREEN + "Game has started!");
     }

--- a/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
+++ b/src/main/java/lol/hyper/compasstracker/tools/GameManager.java
@@ -236,6 +236,8 @@ public class GameManager {
         if (trackingMode.equals("AUTO")) {
             autoTrackingTask = new AutoTrackingTask(this);
             autoTrackingTask.runTaskTimer(compassTracker, 0, 20L * trackingInterval);
+        } else {
+            speedrunnerLocations.put(gameSpeedrunner.getWorld(), gameSpeedrunner.getLocation());
         }
         Bukkit.broadcastMessage(ChatColor.GREEN + "Game has started!");
     }


### PR DESCRIPTION
When the game starts, do the following.

- **Set game time to day**
This ensures a game always starts with light, useful in certain production environments where a server is online for some time before a game is started.
- **Clear runner's and hunters' inventories**
Helps reduce any advantages a player might get by sneakily mining a tree before the game starts.
- **Set runner's and hunters' health, hunger and saturation to 20**
Helps to ensure everyone gets a fair start.